### PR TITLE
Download Crypto Data From BitStamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ om_quant_fin/               # Root directory of the project
 ## OM Quant Fin Features
 
 - Download stock data from Yahoo Finance
+- Download crypto data from the Bitstamp API for a specified crypto.
 - Calculates rolling Z-scores
 - Calculates the rolling ratio of adjusted close and its mean (RSL indicator)
 - Evaluates a model with AUC and Gini for classification models and respective plots
@@ -53,6 +54,9 @@ import om_quant_fin as mql
 
 #Download stock data:
   data = mql.download_data("AAPL", "2020-01-01", "2022-12-31")
+  
+#Download crypto data:
+  data = mql.get_bitstamp_data(currency_pair = "btcusd", start = "01-01-2011")
 
 #Calculates rolling Z-score:
   z_score = mql.rolling_z_score(data["Adj Close"], window = 20)

--- a/om_quant_fin/__init__.py
+++ b/om_quant_fin/__init__.py
@@ -1,5 +1,6 @@
 from .om_quant_fin import (
     download_data,
+    get_bitstamp_data,
     rolling_z_score,
     rolling_ratio,
     calculate_returns,


### PR DESCRIPTION
A new method called get_bitstamp_data() was added to om_quant_fin.py and can be used to get cryptocurrency historical OHCL data just given the symbol and the start date on the dd-mm-aaaa format.

Usage example to get bitcoin historical OHLC data starting on 01-01-2011:

data = get_bitstamp_data(currency_pair="btcusd", start="01-01-2011")